### PR TITLE
Add simple script to parallelize the untarring/ungzipping of the HPA runs

### DIFF
--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+# Script to extract a batch upload of HPA antibodies transferred via FTP
+# Each upload is structured as follows
+# - assays.txt       the assays file for the upload
+# - md5sum.txt       a checksums file
+# - 101.tar          the indidivual TRA files containing the imaging data
+# - 102.tar
+# Each TAR file will be untarred into a directory containing GZIP'ed TIFF
+# files
+
+PREFIX=${PREFIX:-}
+
+# Verify checksums
+md5sum -c md5sum.txt
+#
+for file in $PREFIX*.tar; do
+    tar xvf ${file}
+    id="${file%.*}"
+    gunzip $id/*.gz
+done

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -9,9 +9,11 @@
 # files
 
 PREFIX=${PREFIX:-}
-N=${N:-10}
 
-#
-find $PREFIX*.tar > files.txt
-parallel -a files.txt --jobs $N --joblog log --results results "cat md5sum.txt | grep ' {}' | md5sum -c && tar xvf {} && rm {} && gunzip {/.}/*.gz"
-rm files.txt
+for file in $PREFIX*.tar; do
+    echo "Extracting $file"
+    cat md5sum.txt | grep " $file" | md5sum -c
+    tar xvf ${file}
+    rm $file
+    gunzip ${file%.*}/*.gz
+done

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -3,7 +3,7 @@
 # Each upload is structured as follows
 # - assays.txt       the assays file for the upload
 # - md5sum.txt       a checksums file
-# - 101.tar          the indidivual TRA files containing the imaging data
+# - 101.tar          the indidivual TAR files containing the imaging data
 # - 102.tar
 # Each TAR file will be untarred into a directory containing GZIP'ed TIFF
 # files
@@ -13,5 +13,5 @@ N=${N:-10}
 
 #
 find $PREFIX*.tar > files.txt
-parallel -a files.txt --jobs 10 --joblog log --results results "cat md5sum.txt | grep ' {}' | md5sum -c && tar xvf {} && rm {} && gunzip {/.}/*.gz"
+parallel -a files.txt --jobs $N --joblog log --results results "cat md5sum.txt | grep ' {}' | md5sum -c && tar xvf {} && rm {} && gunzip {/.}/*.gz"
 rm files.txt

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -9,12 +9,9 @@
 # files
 
 PREFIX=${PREFIX:-}
+N=${N:-10}
 
-# Verify checksums
-md5sum -c md5sum.txt
 #
-for file in $PREFIX*.tar; do
-    tar xvf ${file}
-    id="${file%.*}"
-    gunzip $id/*.gz
-done
+find $PREFIX*.tar > files.txt
+parallel -a files.txt --jobs 10 --joblog log --results results "cat md5sum.txt | grep ' {}' | md5sum -c && tar xvf {} && rm {} && gunzip {/.}/*.gz"
+rm files.txt


### PR DESCRIPTION
This needs to be executed with GNU parallel.

Currently tested on the EBI NFS using a test subset of the first HPA antibody import:

```
[sbesson@ebi-cli-001 test]$ ls
1012.tar  1013.tar  101.tar
```