### PR TITLE
Move gunzip into a for loop

### DIFF
--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -15,5 +15,7 @@ for file in $PREFIX*.tar; do
     cat md5sum.txt | grep " $file" | md5sum -c
     tar xvf ${file}
     rm $file
-    gunzip ${file%.*}/*.gz
+    for f in ${file%.*}/*.gz; do
+        gunzip $f
+    done
 done


### PR DESCRIPTION
The extraction of the first HPA upload has revealed that some of the gzipped files are corrupted. The current version of the extraction script will stop the unzipping for each antibody at the first occurrence of an error.
Using a for loop ensures that other TIFF files in an antibody folder keep getting extracted.