### PR TITLE
Some utility scripts

### DIFF
--- a/scripts/util/batchDelete.sh
+++ b/scripts/util/batchDelete.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Deletes all images of the specified dataset in batches.
+# Useful if there are 100 thousands of images in a dataset, because
+# deleting the dataset directly doesn't work in these cases.
+
+datasetId=1753
+batchSize=25
+
+export omero=/opt/omero/server/OMERO.server/bin/omero
+
+$omero login
+
+shopt -s extglob
+
+count=0
+
+while :
+do
+	ids=`$omero hql --ids-only --limit $batchSize --style plain "select link.child from DatasetImageLink link where link.parent.id=$datasetId"`
+
+	if [[ -z $ids ]]
+	then
+		break
+	fi
+
+	ids=${ids//+([[:digit:]]),ImageI:/}
+	ids=${ids//[[:space:]]/,}
+	
+	$omero delete Image:$ids
+
+	count=$((count+$batchSize))
+	
+	d=`date`
+	echo "$d : Deleted $count images so far."
+	
+done

--- a/scripts/util/createThumbnails.sh
+++ b/scripts/util/createThumbnails.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Calls the 'test' command of the render plugin on each image
+# within the specified dataset. This will create the thumbnails,
+# if the import was done with 'skip thumbnails' option.
+
+datasetId=1802
+batchSize=25
+
+export omero=/opt/omero/server/OMERO.server/bin/omero
+
+$omero login
+
+shopt -s extglob
+
+count=0
+
+while :
+do
+	ids=`$omero hql --ids-only --limit $batchSize --style plain "select link.child from DatasetImageLink link where link.parent.id=$datasetId"`
+
+	if [[ -z $ids ]]
+	then
+		break
+	fi
+
+	ids=${ids//+([[:digit:]]),ImageI:/}
+	ids=${ids//[[:space:]]/,}
+	
+	$omero render test Image:$ids
+
+	count=$((count+$batchSize))
+	
+	d=`date`
+	echo "$d : Checked $count images so far."
+	
+done

--- a/scripts/util/image_size_distribution.sh
+++ b/scripts/util/image_size_distribution.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Runs through all directories with numercial directory name
 # and checks the image dimensions of the *.tif files.
 #
@@ -16,7 +18,7 @@ declare -A sizes
 total=`find [0-9]* -maxdepth 0 -type d | wc -l`
 count=0
 
-for d in `find [0-1]* -maxdepth 0 -type d`
+for d in `find [0-9]* -maxdepth 0 -type d`
 do
         for f in `ls $d | grep -i .tif`
         do
@@ -42,13 +44,13 @@ do
         (>&2 echo "( Progress: $count / $total )")
 done
 
-echo "Image size (10^6 pixels),Image dimensions,Number of images"
+echo "Image dimensions,Width,Height,Image size (10^6 pixels),Number of images"
 
 for K in "${!sizes[@]}"
 do
         w=`echo $K | cut -d 'x' -f 1`
         h=`echo $K | cut -d 'x' -f 2`
         s=$(($w*$h/1000000))
-        echo "$s,$K,${sizes[$K]}"
+        echo "$K,$w,$h,$s,${sizes[$K]}"
 done
 

--- a/scripts/util/max_plane_size.sh
+++ b/scripts/util/max_plane_size.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Runs through all directories with numercial directory name
 # and checks the image dimensions of the *.tif files. 
 # Prints out max width and height. Also reports broken tif files.


### PR DESCRIPTION
This PR adds some more utility scripts:

- `batchDelete.sh` Delete images in batches (because the direct deletion of a dataset with 100k+ images won't work)
- `createThumbnails.sh` Calls the render plugin to generate the thumbnails (if images were imported with skip thumbnails option) **(hasn't been tested yet)**
- `image_size_distribution.sh` Runs over all images with `tiffinfo` and generates a CSV file with the distribution of the image sizes
- `max_plane_size.sh` Runs over all images with `tiffinfo` to determine the maximum width and height.
