### PR TITLE
Relinking script

### DIFF
--- a/scripts/create_hpa_datasets.py
+++ b/scripts/create_hpa_datasets.py
@@ -8,10 +8,13 @@ import pandas
 # Files
 annotationsFile = "/home/dlindner/idr0043-experimentA-annotation.csv"
 imageIdsFile = "/home/dlindner/imageIds.txt"
-# psql -h 192.168.53.5 idr omeroreadonly -c 'select child from datasetimagelink where parent = 1351;' > output.txt
-# sed -i 's/[ ]*//' output.txt
-# sed -i 1,2d output.txt
-# head -n -2 output.txt > imageIds.txt
+'''
+psql -h 192.168.53.5 idr omeroreadonly -c 'select child from
+    datasetimagelink where parent = 1351;' > output.txt
+sed -i 's/[ ]*//' output.txt
+sed -i 1,2d output.txt
+head -n -2 output.txt > imageIds.txt
+'''
 
 # OMERO credentials
 user = "root"
@@ -35,7 +38,8 @@ datasetByImageName = {}
 df = pandas.read_csv(annotationsFile)
 for index, row in df.iterrows():
     if row["Image Name"] in datasetByImageName:
-        raise Exception(" !!! line %i : %s has already been added" % (index, row["Image Name"]))
+        raise Exception(" !!! line %i : %s has already been added"
+                        % (index, row["Image Name"]))
     datasetByImageName[row["Image Name"]] = row["Dataset Name"]
 
 datasetByName = {}
@@ -83,4 +87,3 @@ if len(links) > 0:
     conn.getUpdateService().saveAndReturnArray(links)
     done += len(links)
     print "%i images linked." % done
-

--- a/scripts/create_hpa_datasets.py
+++ b/scripts/create_hpa_datasets.py
@@ -1,0 +1,57 @@
+# Example script for reorganizing an HPA run into n datasets, one per antibody
+
+from omero.gateway import BlitzGateway
+import omero.model
+from omero.rtypes import rstring
+
+# Create a BlitzGateway connection
+user = "public"
+password = "public"
+host = "idr.openmicroscopy.org"
+conn = BlitzGateway(user, password, host=host)
+
+# Load HPA dataset with 500K images
+datasetId = 4528768
+dataset = conn.getObject("Dataset", datasetId)
+print "Number of images: %g" % dataset.countChildren()
+
+# Create a dictonary of antibodies. Each key is an antibody ID and the
+# values are the associated image IDs
+antibodies = {}
+
+# TODO: looping over this generator timed out. Probably need to use pagination
+# to load images in batches rather than 500K at once
+for i in dataset.listChildren():
+    # TODO: This code used the annotation for testing - the mapping should
+    # probably either use the imported file paths or the
+    # assays.txt/annotation.csv
+    ann = i.getAnnotation('openmicroscopy.org/mapr/antibody')
+    kv = ann.getValue()[0]
+    if kv[0] != 'Antibody Identifier':
+        print 'Missing antibody for image %g' % i.id
+    antibody = kv[1]
+    antibodies.setdefault(kv[1], []).append(i.id)
+print "Found %g antibodies" % len(antibodies)
+
+
+# Create dataset and dataset/image links in batches
+for antibodyName, imageIds in antibodies.iteritems():
+    # Create new dataset using the antibody ID as the name
+    # This is not idempotent and will recreate 1K datasets
+    dataset = omero.model.DatasetI()
+    dataset.setName(rstring(antibodyName))
+
+    # Create an array of links
+    links = []
+    for imageId in imageIds:
+        link = omero.model.DatasetImageLinkI()
+        link.parent = dataset
+        link.child.id = imageId
+        links.append(links)
+
+    # Create the array of links
+    links = conn.getUpdateService().saveAndReturnArray(links)
+    print "Created dataset %s with %g images" % (antibodyName, len(imageIds))
+
+    # TODO: return the dataset ID and create a project/dataset link. Otherwise
+    # all datasets will be orphaned


### PR DESCRIPTION
Script for moving the 500k images of the HPA dataset into separate datasets, one for each antibody.
This is vaguely based on @sbesson 's commit 800d86d . 

The script only creates the antibody datasets and links the images to the datasets. The old dataset with the 500k images still has to be deleted manually, including the old image links, but obviously not the images themselves. 

It needs an updated annotation.csv containing the image names and dataset names, and a list of all image ids (this is used to avoid the `dataset.listChildren()` call which is not feasible).
