### PR TITLE
get_dataset_ids script improvements

### DIFF
--- a/scripts/util/get_dataset_ids.py
+++ b/scripts/util/get_dataset_ids.py
@@ -9,7 +9,6 @@ annotation.csv and prints them to std out.
 import sys
 # Files
 annoFile = sys.argv[1]
-# annoFile = "../../experimentA/hpa_run_02/idr0043-experimentA-annotation.csv.gz"
 
 # OMERO credentials
 user = "public"

--- a/scripts/util/get_dataset_ids.py
+++ b/scripts/util/get_dataset_ids.py
@@ -6,12 +6,14 @@ This script simply gets the IDs of the datasets referenced in the
 annotation.csv and prints them to std out.
 '''
 
+import sys
 # Files
-annoFile = "../../experimentA/hpa_run_01/idr0043-experimentA-annotation.csv"
+annoFile = sys.argv[1]
+# annoFile = "../../experimentA/hpa_run_02/idr0043-experimentA-annotation.csv.gz"
 
 # OMERO credentials
-user = "root"
-password = "xxx"
+user = "public"
+password = "public"
 host = "localhost"
 
 # HPA Project id
@@ -30,4 +32,4 @@ conn.connect()
 project = conn.getObject("Project", projectId)
 for ds in project.listChildren():
     if ds.name in datasets:
-        print ds.id
+        print 'Dataset:%s' % ds.id


### PR DESCRIPTION
- use command-line argument rather than hardcoding annotation file
- use public credentials for retrieving IDs
- print out the complete `Dataset:id` form for consumption by plugins

With these changes I was able to generate the list of datasets for the second import run and start the thumbnail generation across 5 threads with the following commands:

```
PYTHONPATH=/opt/omero/server/OMERO.server/lib/python/ python get_dataset_ids.py ~/idr0043-uhlen-humanproteinatlas/experimentA/hpa_run_02/idr0043-experimentA-annotation.csv.gz > ~/hpa_run_02_datasets.txt
parallel -a ~/hpa_run_02_datasets.txt --results /tmp/hpa_run_02_thumbs/ -j5 /opt/omero/server/OMERO.server/bin/omero -s localhost -u demo -w <PASS> render set {} idr0043-uhlen-humanproteinatlas/experimentA/rendering_settings.yml
```